### PR TITLE
Add asset_path helper to precompile example

### DIFF
--- a/examples/express/bin/precompile_assets.js
+++ b/examples/express/bin/precompile_assets.js
@@ -7,7 +7,8 @@ var Mincer = require('mincer'),
     fs = require('fs'),
     zlib = require('zlib'),
     async = require('async'),
-    wrench = require('wrench')
+    wrench = require('wrench'),
+    mountPoint = '/assets'
 ;
 
 // remove existing manifest/assets if it exists
@@ -19,6 +20,15 @@ var environment = new Mincer.Environment('./');
 
 environment.registerHelper('version', function() {
   return require(__dirname + '/../../../package.json').version;
+});
+
+environment.registerHelper('asset_path', function(name, opts) {
+  var asset = environment.findAsset(name, opts);
+  if (!asset){
+    throw new Error("File [" + name + "] not found");
+  }
+
+  return mountPoint + '/' + asset.digestPath;
 });
 
 /**


### PR DESCRIPTION
This adds an asset_path helper and updates the error messaging in the precompile script.

I think it would be helpful if connect-mincer and/or mincer docs would include an example of using  the asset_path helper inside of a stylus file. I took me some time to translate the ejs example. Something as simple as this:

``` css
background: url(asset_path('background.jpg'));
```
