### PR TITLE
Expose Mincer once instantiated so Engine Options can be set at runtime

### DIFF
--- a/lib/connect-mincer.js
+++ b/lib/connect-mincer.js
@@ -8,6 +8,7 @@ var Mincer = require('mincer'),
 var ConnectMincer = (function() {
 
   function ConnectMincer(opts) {
+    this.Mincer = Mincer;
     this.production = opts.production === true ? true : false;
     this.options = opts;
 


### PR DESCRIPTION
Mincer sets its CoffeeScript Engine to "bare" by default (against the CoffeeScript default). By default I mean when compiling .coffee with coffee -c the top level function safety wrapper is applied to the file.

So exposing Mincer in this commit allows this option to be changed back to the default at runtime when using connect-mincer and as a side effect, any option for any of the engines can be set as well (that Mincer supports anyway).

```
var ConnectMincer = require('connect-mincer');
var connectMincer = new ConnectMincer({
   /* */
});

connectMincer.Mincer.CoffeeEngine.setOptions({bare: false});
```
